### PR TITLE
Add fetching of energy limits to IRF class

### DIFF
--- a/gravitational_wave_toy/ctairf.py
+++ b/gravitational_wave_toy/ctairf.py
@@ -71,8 +71,8 @@ class IRF(BaseModel):
     n_sst: Optional[int] = None
     n_mst: Optional[int] = None
     n_lst: Optional[int] = None
-    energy_min: Optional[u.Quantity] = None
-    energy_max: Optional[u.Quantity] = None
+    energy_min: Optional[float] = None
+    energy_max: Optional[float] = None
     version: Optional[str] = None
 
     @validator("base_directory", pre=True)


### PR DESCRIPTION
This pull request adds the functionality to fetch energy limits to the IRF class. The energy limits are now represented as float values instead of Quantity objects. This change ensures consistency and improves the usability of the class. This fix addresses issue #16.