### PR TITLE
Allow for observation time estimation with pre-calculated simulations

### DIFF
--- a/gravitational_wave_toy/followup.py
+++ b/gravitational_wave_toy/followup.py
@@ -17,16 +17,6 @@ def get_row(
     config: str = "alpha",
     duration: int = 1800,
 ):
-    if site not in ["north", "south"]:
-        raise ValueError("site must be north or south")
-    if zenith not in [20, 40, 60]:
-        raise ValueError("zenith must be 20, 40 or 60")
-    if software not in ["gammapy", "ctools"]:
-        raise ValueError("software must be gammapy or ctools")
-    if config not in ["alpha", "omega"]:
-        raise ValueError("config must be alpha or omega")
-    if duration != 1800:
-        raise ValueError("Duration must be 1800")
 
     # find row with these values
     rows = sens_df[
@@ -62,16 +52,6 @@ def get_sensitivity(
     min_energy: u.Quantity = 0.03 * u.TeV,
     max_energy: u.Quantity = 10 * u.TeV,
 ):
-    if site not in ["north", "south"]:
-        raise ValueError("site must be north or south")
-    if zenith not in [20, 40, 60]:
-        raise ValueError("zenith must be 20, 40 or 60")
-    if software not in ["gammapy", "ctools"]:
-        raise ValueError("software must be gammapy or ctools")
-    if config not in ["alpha", "omega"]:
-        raise ValueError("config must be alpha or omega")
-    if duration != 1800:
-        raise ValueError("Duration must be 1800")
 
     row = get_row(
         sens_df=sens_df,
@@ -130,16 +110,6 @@ def get_exposure(
         raise ValueError(f"max_energy must be an energy quantity, got {max_energy}")
     if radius.unit.physical_type != "angle":
         raise ValueError(f"radius must be an angle quantity, got {radius}")
-    if site not in ["north", "south"]:
-        raise ValueError("site must be north or south")
-    if zenith not in [20, 40, 60]:
-        raise ValueError("zenith must be 20, 40 or 60")
-    if software not in ["gammapy", "ctools"]:
-        raise ValueError("software must be gammapy or ctools")
-    if config not in ["alpha", "omega"]:
-        raise ValueError("config must be alpha or omega")
-    if duration != 1800:
-        raise ValueError("Duration must be 1800")
     if target_precision.unit.physical_type != "time":
         raise ValueError(
             f"target_precision must be a time quantity, got {target_precision}"

--- a/gravitational_wave_toy/followup.py
+++ b/gravitational_wave_toy/followup.py
@@ -40,10 +40,11 @@ def get_row(
 
 
 def get_sensitivity(
-    sens_df: pd.DataFrame,
     event_id: int,
     site: str,
     zenith: int,
+    sens_df: pd.DataFrame | None = None,
+    sens_curve: list | None = None,
     ebl: bool = False,
     software: str = "gammapy",
     config: str = "alpha",
@@ -52,19 +53,26 @@ def get_sensitivity(
     min_energy: u.Quantity = 0.03 * u.TeV,
     max_energy: u.Quantity = 10 * u.TeV,
 ):
+    
+    if sens_df is None and sens_curve is None:
+        raise ValueError("Must provide either sens_df or sens_curve")
+    if sens_df:
 
-    row = get_row(
-        sens_df=sens_df,
-        event_id=event_id,
-        site=site,
-        zenith=zenith,
-        ebl=ebl,
-        software=software,
-        config=config,
-        duration=duration,
-    )
+        row = get_row(
+            sens_df=sens_df,
+            event_id=event_id,
+            site=site,
+            zenith=zenith,
+            ebl=ebl,
+            software=software,
+            config=config,
+            duration=duration,
+        )
 
-    curve = row["sensitivity_curve"]
+        curve = row["sensitivity_curve"]
+        
+    else:
+        curve = sens_curve
 
     if software == "gammapy":
         sens = sensitivity.SensitivityGammapy(
@@ -85,12 +93,13 @@ def get_sensitivity(
 
 
 def get_exposure(
-    sens_df: pd.DataFrame,
     grb_filepath: Path | str,
     event_id: int,
     delay: u.Quantity,
     site: str,
     zenith: int,
+    sens_df: pd.DataFrame | None = None,
+    sens_curve: list | None = None,
     ebl: str | None = None,
     software: str = "gammapy",
     config: str = "alpha",
@@ -125,10 +134,11 @@ def get_exposure(
     max_time = max_time.to("s")
 
     sens = get_sensitivity(
-        sens_df=sens_df,
         event_id=event_id,
         site=site,
         zenith=zenith,
+        sens_df=sens_df,
+        sens_curve=sens_curve,
         ebl=bool(ebl),
         software=software,
         config=config,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dask = "^2023.12.0"
 tqdm = "^4.66.1"
 pyarrow = "^14.0.1"
 gammapy = "^1.1"
-pydantic = "^2.5.2"
+pydantic = "^1.0"
 
 [tool.poetry.group.dev.dependencies]
 ipython = "^8.18.1"


### PR DESCRIPTION
This pull request fixes issue #19 by allowing for sensitivity estimation with IRFs extracted from data runs. It includes several changes to the code, removing unnecessary input checks, and allowing the sensitivity curve to be provided directly. The changes also include the addition of the estimate_sensitivity() method to handle pre-calculated observation times provided as a parquet file.