### PR TITLE
Make `followup` module more robust (Addresses #37)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@
 - [Authors](#️authors)
 - [Instructions](#instructions)
   - [GW Observations](#instructions-gw-obs)
+    - [Example Simulation](#example-simulation)
+    - [Example followup calculation](#example-followup)
   - [Reading Results](#instructions-reading)
   - [Plotting Heatmaps](#instructions-plotting)
 
@@ -91,7 +93,7 @@ This code simulates observations of simulated gravitational wave events to deter
 
 - a dictionary object containing detection information and parameters of the event itself (extracted from the model)
 
-#### Example
+#### Example Simulation<a name ="example-simulation"></a>
 
 ```python
 from astropy import units as u
@@ -144,6 +146,54 @@ res = grb.observe(
 
 print(f"Observation time at delay={delay_time} is {res_ebl['obs_time']} with EBL={res_ebl['ebl_model']}")
 # Obs time at delay=1800.0 s is 1292.0 s with EBL=franceschini
+```
+
+### Example followup calculation<a name ="example-followup"></a>
+
+```python
+import astropy.units as u
+import pandas as pd
+from gravitational_wave_toy import followup
+
+lookup_talbe = "./O5_gammapy_observations_v4.parquet"
+
+# optional, but it's recommended to load the DataFrame first save time
+# otherwise you can directly pass the filepath to the get_exposure method
+lookup_df = pd.read_parquet(lookup_talbe)
+
+event_id = 1
+delay = 10 * u.s
+site = "north"
+zenith = 60
+ebl = "franceschini"
+
+
+followup.get_exposure(
+    event_id=event_id,
+    delay=delay,
+    site=site,
+    zenith=zenith,
+    extrapolation_df=lookup_df,
+    ebl=ebl,
+)
+
+# returns, e.g.
+# {
+#     'long': <Quantity 2.623 rad>,
+#     'lat': <Quantity 0.186 rad>,
+#     'eiso': <Quantity 2.67e+50 erg>,
+#     'dist': <Quantity 466000. kpc>,
+#     'obs_time': <Quantity 169. s>,
+#     'error_message': '',
+#     'angle': <Quantity 24.521 deg>,
+#     'ebl_model': 'franceschini',
+#     'min_energy': <Quantity 0.02 TeV>,
+#     'max_energy': <Quantity 10. TeV>,
+#     'seen': True,
+#     'start_time': <Quantity 10. s>,
+#     'end_time': <Quantity 179. s>,
+#     'id': 4
+# }
 ```
 
 ### Reading Results<a name = "instructions-reading"></a>

--- a/gravitational_wave_toy/followup.py
+++ b/gravitational_wave_toy/followup.py
@@ -206,8 +206,8 @@ def get_exposure(
         obs_info["ebl_model"] = obs_info.pop("irf_ebl_model")
         
         # add other units
-        obs_info["long"] = obs_info["long"] * u.deg
-        obs_info["lat"] = obs_info["lat"] * u.deg
+        obs_info["long"] = obs_info["long"] * u.rad
+        obs_info["lat"] = obs_info["lat"] * u.rad
         obs_info["eiso"] = obs_info["eiso"] * u.erg
         obs_info["dist"] = obs_info["dist"] * u.kpc
         


### PR DESCRIPTION
This pull request addresses several urgent issues in the `followup` module. It makes the module more robust by fixing the following issues:

- If the delay is too short, the followup calculation still goes ahead and raises an error. This has been fixed by raising a ValueError with an appropriate error message.

- If the event is never detectable at any delay, the followup calculation still attempts to go ahead and raises an error. This has been fixed by checking if the event is detectable and returning an error message if it is not.

- If the delay requested is outside the extrapolation range, a warning is now posted. This ensures that users are aware when the delay is outside the valid range.

- The event is now marked as `seen=False` if the exposure needed for detection takes longer than the `max_time` parameter. This provides more accurate information about the event.

- Units have been added to all outputs to improve clarity and consistency.

In addition to these fixes, an example for how to use the `followup` module has been added to the readme. The example demonstrates how to use the module with and without a lookup table.

Please review and merge this pull request to improve the robustness and usability of the `followup` module.